### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   phpstan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/FOSSBilling/example-module/security/code-scanning/2](https://github.com/FOSSBilling/example-module/security/code-scanning/2)

In general, the fix is to explicitly set minimal `GITHUB_TOKEN` permissions using a `permissions` block, either at the workflow root (applies to all jobs) or per job. Since both jobs in this workflow only read code and metadata (no writes to the repo, issues, or PRs), the minimal appropriate permission is `contents: read`.

The best fix without changing functionality is to add a root-level `permissions` block just under the `on:` section, applying to both `phpstan` and `phpstan-release` jobs. This keeps the workflow behavior unchanged while constraining the token. Specifically, in `.github/workflows/php-ci.yml`, after line 7 (the end of the `on:` triggers) and before line 9 (`jobs:`), insert:

```yaml
permissions:
  contents: read
```

No imports or additional definitions are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
