### PR TITLE
Fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Checkout FOSSBilling Source Code
+      - name: Checkout FOSSBilling
         uses: actions/checkout@v6
         with:
           repository: "FOSSBilling/FOSSBilling"

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   phpstan:
     runs-on: ubuntu-latest

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           args: --working-dir=FOSSBilling
           dev: no
+          php_version: 8.3
           php_extensions: intl
 
       - name: Run PHPStan
@@ -63,6 +64,7 @@ jobs:
         with:
           args: --working-dir=FOSSBilling/
           dev: no
+          php_version: 8.3
           php_extensions: intl
 
       - name: Run PHPStan

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Install Composer Dependencies
         uses: php-actions/composer@v6
         with:
-          args: --working-dir=FOSSBilling
           dev: no
           php_version: 8.3
           php_extensions: intl
@@ -63,7 +62,6 @@ jobs:
       - name: Install Composer Dependencies
         uses: php-actions/composer@v6
         with:
-          args: --working-dir=FOSSBilling/
           dev: no
           php_version: 8.3
           php_extensions: intl

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     name: PHPStan - FOSSBilling Preview
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Checkout FOSSBilling Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: "FOSSBilling/FOSSBilling"
           path: "FOSSBilling"
@@ -44,7 +44,7 @@ jobs:
 
     name: PHPStan - FOSSBilling Release
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Get the Latest FOSSBilling Release Tag
         uses: oprypin/find-latest-tag@v1
@@ -54,7 +54,7 @@ jobs:
         id: get_id
 
       - name: Checkout The Release tag
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: "FOSSBilling/FOSSBilling"
           path: "FOSSBilling"

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Install Composer Dependencies
         uses: php-actions/composer@v6
         with:
+          args: --working-dir=FOSSBilling
           dev: no
           php_version: 8.3
           php_extensions: intl
@@ -62,6 +63,7 @@ jobs:
       - name: Install Composer Dependencies
         uses: php-actions/composer@v6
         with:
+          args: --working-dir=FOSSBilling
           dev: no
           php_version: 8.3
           php_extensions: intl

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           args: --working-dir=FOSSBilling
           dev: no
+          php_extensions: intl
 
       - name: Run PHPStan
         uses: php-actions/phpstan@v3
@@ -62,6 +63,7 @@ jobs:
         with:
           args: --working-dir=FOSSBilling/
           dev: no
+          php_extensions: intl
 
       - name: Run PHPStan
         uses: php-actions/phpstan@v3

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Run PHPStan
         uses: php-actions/phpstan@v3
         with:
-          php_version: latest
+          version: latest
+          php_version: 8.3
           configuration: phpstan.neon
           memory_limit: 512M
 
@@ -70,6 +71,7 @@ jobs:
       - name: Run PHPStan
         uses: php-actions/phpstan@v3
         with:
-          php_version: latest
+          version: latest
+          php_version: 8.3
           configuration: phpstan.neon
           memory_limit: 512M

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -46,14 +46,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Get the Latest FOSSBilling Release Tag
+      - name: Get Latest FOSSBilling Release Tag
         uses: oprypin/find-latest-tag@v1
         with:
           repository: "FOSSBilling/FOSSBilling"
           releases-only: true
         id: get_id
 
-      - name: Checkout The Release tag
+      - name: Checkout Release tag
         uses: actions/checkout@v6
         with:
           repository: "FOSSBilling/FOSSBilling"


### PR DESCRIPTION
Potential fix for [https://github.com/FOSSBilling/example-module/security/code-scanning/1](https://github.com/FOSSBilling/example-module/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions:` block that grants only the minimal required access to the `GITHUB_TOKEN`. For this workflow, both jobs only need to read repository contents and tags/releases. They do not need to push commits, modify PRs, or interact with issues. Therefore, `contents: read` is sufficient for the entire workflow.

The best fix without changing functionality is to add a root‑level `permissions:` block (so it applies to all jobs) directly under the `name:` or `on:` section in `.github/workflows/php-ci.yml`. Set it to `contents: read`, which mirrors the minimal suggested by CodeQL. There is no evidence that other scopes (like `pull-requests` or `issues`) are needed, and none of the used actions document a requirement for write permissions in this use case. No additional methods, imports, or definitions are needed, since this is purely a YAML configuration change to the workflow file.

Concretely:
- Edit `.github/workflows/php-ci.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

near the top of the file at workflow scope, e.g., after the `on:` block (or directly after `name:`; either is valid). This will ensure both `phpstan` and `phpstan-release` jobs run with a read‑only `GITHUB_TOKEN`, resolving the CodeQL finding.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
